### PR TITLE
Convert app to menu bar (tray) window

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,28 +1,59 @@
-import { app, shell, BrowserWindow, ipcMain } from 'electron'
+import { app, shell, BrowserWindow, ipcMain, Tray, nativeImage } from 'electron'
 import { join } from 'path'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
-import icon from '../../resources/icon.png?asset'
 import { importIcsToCalendar } from './importIcs'
 
-function createWindow(): void {
-  // Create the browser window.
-  const mainWindow = new BrowserWindow({
-    width: 900,
-    height: 670,
+let tray: Tray | null = null
+let trayWindow: BrowserWindow | null = null
+
+function getTrayIcon() {
+  const iconPath = join(__dirname, '../../resources/icon.png')
+  const image = nativeImage.createFromPath(iconPath)
+  return process.platform === 'darwin' ? image.resize({ width: 18, height: 18 }) : image
+}
+
+function toggleTrayWindow(): void {
+  if (!trayWindow || trayWindow.isDestroyed()) return
+  if (tray && !tray.isDestroyed()) {
+    const trayBounds = tray.getBounds()
+    const windowBounds = trayWindow.getBounds()
+    const padding = 8
+    const x = Math.round(
+      trayBounds.x + trayBounds.width / 2 - windowBounds.width / 2
+    )
+    const y = Math.round(trayBounds.y + trayBounds.height + padding)
+    trayWindow.setPosition(x, y, false)
+  }
+  if (trayWindow.isVisible()) {
+    trayWindow.hide()
+    return
+  }
+
+  trayWindow.show()
+  trayWindow.focus()
+}
+
+function createTrayWindow(): void {
+  trayWindow = new BrowserWindow({
+    width: 420,
+    height: 520,
     show: false,
+    frame: false,
+    resizable: false,
+    fullscreenable: false,
     autoHideMenuBar: true,
-    ...(process.platform === 'linux' ? { icon } : {}),
+    skipTaskbar: true,
     webPreferences: {
       preload: join(__dirname, '../preload/index.js'),
       sandbox: false
     }
   })
 
-  mainWindow.on('ready-to-show', () => {
-    mainWindow.show()
+  trayWindow.on('blur', () => {
+    trayWindow?.hide()
   })
 
-  mainWindow.webContents.setWindowOpenHandler((details) => {
+  trayWindow.webContents.setWindowOpenHandler((details) => {
     shell.openExternal(details.url)
     return { action: 'deny' }
   })
@@ -30,10 +61,16 @@ function createWindow(): void {
   // HMR for renderer base on electron-vite cli.
   // Load the remote URL for development or the local html file for production.
   if (is.dev && process.env['ELECTRON_RENDERER_URL']) {
-    mainWindow.loadURL(process.env['ELECTRON_RENDERER_URL'])
+    trayWindow.loadURL(process.env['ELECTRON_RENDERER_URL'])
   } else {
-    mainWindow.loadFile(join(__dirname, '../renderer/index.html'))
+    trayWindow.loadFile(join(__dirname, '../renderer/index.html'))
   }
+}
+
+function createTray(): void {
+  tray = new Tray(getTrayIcon())
+  tray.setToolTip('Calendar Cloner')
+  tray.on('click', toggleTrayWindow)
 }
 
 // This method will be called when Electron has finished
@@ -61,13 +98,16 @@ app.whenReady().then(() => {
   console.log("[renderer]", ...args);
 });
 
-
-  createWindow()
+  if (process.platform === 'darwin') {
+    app.dock.hide()
+  }
+  createTrayWindow()
+  createTray()
 
   app.on('activate', function () {
     // On macOS it's common to re-create a window in the app when the
     // dock icon is clicked and there are no other windows open.
-    if (BrowserWindow.getAllWindows().length === 0) createWindow()
+    if (BrowserWindow.getAllWindows().length === 0) createTrayWindow()
   })
 })
 


### PR DESCRIPTION
### Motivation
- Provide a lightweight menu-bar style UX so the calendar-cloner functionality can be accessed from the macOS menu bar while preserving the existing import flow.
- Keep the renderer/UI and existing calendar import logic intact so behavior remains functionally identical to the original app.

### Description
- Replaced the original main `BrowserWindow` with a frameless popover `trayWindow` and added a `Tray` icon, implemented in `src/main/index.ts`.
- Added `getTrayIcon`, `createTrayWindow`, `createTray`, and `toggleTrayWindow` helpers and wired a tray click to show/hide the popover, positioning it beneath the tray using `tray.getBounds()` and `trayWindow.setPosition`.
- Set the tray window to `frame: false`, `skipTaskbar: true`, auto-hide on blur, and continued to load the same renderer (`../renderer/index.html` or the dev `ELECTRON_RENDERER_URL`) so UI and IPC (`calendar:importIcs`) remain unchanged.
- Hid the macOS dock icon with `app.dock.hide()` to make the app behave like a native menu bar utility.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985c6eadfc0832dad5c609628200e5e)