### PR TITLE
Replace remaining Calendar Cloner strings with Custom Calendar language

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# calendar-cloner
+# CustomCal
 
 An Electron application with React and TypeScript
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,5 +1,5 @@
 appId: com.electron.app
-productName: calendar-cloner
+productName: CustomCal
 directories:
   buildResources: build
 files:
@@ -12,7 +12,7 @@ files:
 asarUnpack:
   - resources/**
 win:
-  executableName: calendar-cloner
+  executableName: CustomCal
 nsis:
   artifactName: ${name}-${version}-setup.${ext}
   shortcutName: ${productName}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "calendar-cloner",
-  "version": "1.0.0",
+  "name": "CustomCal",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "calendar-cloner",
-      "version": "1.0.0",
+      "name": "CustomCal",
+      "version": "0.0.1",
       "hasInstallScript": true,
       "dependencies": {
         "@electron-toolkit/preload": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "calendar-cloner",
-  "version": "1.0.0",
+  "name": "CustomCal",
+  "version": "0.0.1",
   "description": "An Electron application with React and TypeScript",
   "main": "./out/main/index.js",
   "author": "example.com",

--- a/src/main/importIcs.ts
+++ b/src/main/importIcs.ts
@@ -49,7 +49,7 @@ export async function importIcsToCalendar(opts: {
   const url = normalizeIcsUrl(opts.icsUrl)
 
   const data: Record<string, any> = await (ical.async.fromURL as any)(url, {
-    headers: { 'User-Agent': 'CalendarCloner/0.1' }
+    headers: { 'User-Agent': 'CustomCalendar/0.0.1' }
   })
 
   const oneDay = 24 * 60 * 60 * 1000
@@ -317,7 +317,7 @@ let resultData = try JSONSerialization.data(withJSONObject: result, options: [])
 FileHandle.standardOutput.write(resultData)
 `
 
-  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'calendar-cloner-'))
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'CustomCal-'))
   const scriptPath = path.join(tmpDir, 'import.swift')
   const payloadPath = path.join(tmpDir, 'payload.json')
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -69,7 +69,7 @@ function createTrayWindow(): void {
 
 function createTray(): void {
   tray = new Tray(getTrayIcon())
-  tray.setToolTip('Calendar Cloner')
+  tray.setToolTip('Custom Calendar')
   tray.on('click', toggleTrayWindow)
 }
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -29,7 +29,7 @@ export default function App() {
 
   return (
     <div style={{ padding: 16, fontFamily: 'system-ui' }}>
-      <h2>Calendar Cloner (MVP)</h2>
+      <h2>Custom Calendar (MVP)</h2>
 
       <div>
         <div>Paste your iCal / webcal URL:</div>


### PR DESCRIPTION
### Motivation
- Finish renaming the product copy to the new application identity so UI strings, tooltips, and external identifiers are consistent with the `CustomCal` rename. 
- Ensure requests and runtime artifacts use the new branding to avoid mixing old project names in telemetry or logs.

### Description
- Replaced the main UI heading `Calendar Cloner (MVP)` with `Custom Calendar (MVP)` in `src/renderer/src/App.tsx`.
- Updated the tray tooltip from `Calendar Cloner` to `Custom Calendar` in `src/main/index.ts`.
- Updated the import request `User-Agent` header to `CustomCalendar/0.0.1` in `src/main/importIcs.ts`.
- Left the previously-updated temporary directory prefix `CustomCal-` in `src/main/importIcs.ts` (aligned with earlier rename).

### Testing
- Ran a targeted search with `rg` to verify no remaining `Calendar Cloner`, `CalendarCloner`, or `cloner` strings remained in `src` and key metadata files and found none. (success)
- Ran `npm run typecheck` which still fails due to an existing TypeScript issue: `src/main/index.ts(102,5): 'app.dock' is possibly 'undefined'`. (failed)
- Attempted `npm run dev` to exercise the UI, but Electron failed to start in this environment due to a missing system library (`libatk-1.0.so.0`), preventing runtime verification. (blocked)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d5ae41778832db7451df3242e7195)